### PR TITLE
Refactor TypeScanner for DI and testability

### DIFF
--- a/Registerly/src/Registration/RegistrationTaskBuilder.cs
+++ b/Registerly/src/Registration/RegistrationTaskBuilder.cs
@@ -5,20 +5,25 @@ using DeviantCoding.Registerly.Strategies;
 
 namespace DeviantCoding.Registerly.Registration;
 
-internal class RegistrationTaskBuilder() : IEnumerable<IRegistrationTask>,
+internal class RegistrationTaskBuilder(TypeScanner typeScanner) : IEnumerable<IRegistrationTask>,
     IClassSource,
     IClassSourceResult, ILifetimeDefinitionResult, IMappingStrategyDefinitionResult, IRegistrationStrategyDefinitionResult, IStrategyDefinitionResult
 {
     private readonly List<RegistrationTask> _tasks = [];
 
+    public RegistrationTaskBuilder() : this(TypeScanner.Default)
+    {
+        
+    }
+
     IClassSourceResult IClassSource.FromAssemblies(IEnumerable<Assembly> assemblies)
-        => AddNew(() => TypeScanner.From(assemblies));
+        => AddNew(() => typeScanner.From(assemblies));
 
     IClassSourceResult IClassSource.From(IEnumerable<Type> candidates)
-        => AddNew(() => TypeScanner.From(candidates));
+        => AddNew(() => typeScanner.From(candidates));
 
     IClassSourceResult IClassSource.FromDependencyContext()
-        => AddNew(() => TypeScanner.FromDependencyContext());
+        => AddNew(() => typeScanner.FromDependencyContext());
 
     IClassSourceResult IClassSource.Where(ClassFilterDelegate predicate)
     {

--- a/Registerly/src/Scanning/TypeScanner.cs
+++ b/Registerly/src/Scanning/TypeScanner.cs
@@ -6,12 +6,23 @@ namespace DeviantCoding.Registerly.Scanning;
 public delegate IQueryable<Type> SourceSelectorDelegate();
 public delegate bool ClassFilterDelegate(Type type);
 
-internal static class TypeScanner
+internal interface ITypeScanner
 {
-    public static IQueryable<Type> FromDependencyContext(ClassFilterDelegate? typeFilter = null)
+    IQueryable<Type> From(IEnumerable<Assembly> assemblies, ClassFilterDelegate? typeFilter = null);
+    IQueryable<Type> From(IEnumerable<AssemblyName> assemblyNames, ClassFilterDelegate typeFilter);
+    IQueryable<Type> From(IEnumerable<Type> classes);
+    IQueryable<Type> FromDependencyContext(ClassFilterDelegate? typeFilter = null);
+    IQueryable<Type> FromDependencyContext(DependencyContext context, Func<AssemblyName, bool> assemblyFilter, ClassFilterDelegate typeFilter);
+}
+
+internal class TypeScanner : ITypeScanner
+{
+    public static TypeScanner Default { get; } = new();
+
+    public IQueryable<Type> FromDependencyContext(ClassFilterDelegate? typeFilter = null)
         => FromDependencyContext(DependencyContext.Default ?? throw new InvalidOperationException("No default dependency context found"), _ => true, typeFilter ?? new ClassFilterDelegate(_ => true));
 
-    public static IQueryable<Type> FromDependencyContext(DependencyContext context, Func<AssemblyName, bool> assemblyFilter, ClassFilterDelegate typeFilter)
+    public IQueryable<Type> FromDependencyContext(DependencyContext context, Func<AssemblyName, bool> assemblyFilter, ClassFilterDelegate typeFilter)
     {
         var assemblyNames = context.RuntimeLibraries
             .SelectMany(library => library.GetDefaultAssemblyNames(context))
@@ -22,13 +33,13 @@ internal static class TypeScanner
             .FromAssemblyNames(assemblyNames, typeFilter);
     }
 
-    public static IQueryable<Type> From(IEnumerable<AssemblyName> assemblyNames, ClassFilterDelegate typeFilter)
+    public IQueryable<Type> From(IEnumerable<AssemblyName> assemblyNames, ClassFilterDelegate typeFilter)
         => new AssemblyLoader().FromAssemblyNames(assemblyNames, typeFilter);
 
-    public static IQueryable<Type> From(IEnumerable<Assembly> assemblies, ClassFilterDelegate? typeFilter = null)
+    public IQueryable<Type> From(IEnumerable<Assembly> assemblies, ClassFilterDelegate? typeFilter = null)
         => new AssemblyLoader().FromAssemblies(assemblies, typeFilter);
 
-    public static IQueryable<Type> From(IEnumerable<Type> classes)
+    public IQueryable<Type> From(IEnumerable<Type> classes)
         => classes
             .Where(t => t.IsRegistrable())
             .AsQueryable();

--- a/Registerly/test/UnitTests/DeviantCoding.Registerly.UnitTests.csproj
+++ b/Registerly/test/UnitTests/DeviantCoding.Registerly.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -19,11 +19,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\DeviantCoding.Registerly.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
-    <Using Include="FluentAssertions" />
   </ItemGroup>
 
 </Project>

--- a/Registerly/test/UnitTests/TypeScannerTests.cs
+++ b/Registerly/test/UnitTests/TypeScannerTests.cs
@@ -12,17 +12,19 @@ namespace DeviantCoding.Registerly.UnitTests
         [Transient<AsSelf>] public class TypeScannerClass3 { }
         [Singleton<AsSelf>] public class TypeScannerClass4 { }
 
-
+        private readonly TypeScanner _sut = new();
+        
         private static Type[] DecoratedTypes = 
             [
             typeof(TypeScannerClass1), typeof(TypeScannerClass2), typeof(TypeScannerClass3), 
             typeof(TypeScannerClass4)
             ];
 
+
         [Fact]
         public void Should_succesfully_execute_FromDependencyContext()
         {
-            var types = TypeScanner
+            var types = _sut
                 .FromDependencyContext()
                 .Where( t => t.Name.StartsWith("TypeScannerClass"));
 
@@ -32,7 +34,7 @@ namespace DeviantCoding.Registerly.UnitTests
         [Fact]
         public void Should_succesfully_execute_FromAssemblyNames()
         {
-            var types = TypeScanner
+            var types = _sut
                 .From([typeof(TypeScannerTests).Assembly.GetName()], _ => true)
                 .Where(t => t.Name.StartsWith("TypeScannerClass"));
 
@@ -55,7 +57,7 @@ namespace DeviantCoding.Registerly.UnitTests
         [Fact]
         public void Should_apply_AssignableTo()
         {
-            TypeScanner.From(DecoratedTypes)
+            _sut.From(DecoratedTypes)
                 .Where(t => t.AssignableTo<ITypeScannerInterface1>())
                 .Should().OnlyContain(t => new[] { typeof(TypeScannerClass1), typeof(TypeScannerClass2) }.Contains(t));
 


### PR DESCRIPTION
- Modify `RegistrationTaskBuilder` to accept `TypeScanner` parameter.
- Add default constructor to `RegistrationTaskBuilder` initializing `TypeScanner.Default`.
- Refactor `TypeScanner` from static class to `ITypeScanner` interface and concrete class.
- Convert `TypeScanner` methods from static to instance methods.
- Update `DeviantCoding.Registerly.UnitTests.csproj` to remove unnecessary `<Using>` elements for `Xunit` and `FluentAssertions`.